### PR TITLE
doc: avoid redirection to github 404 page in readme documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Droids and Druids
 
-Página oficial del podcast [droidsanddruids.com](droidsanddruids.com)
+Página oficial del podcast [droidsanddruids.com](https://droidsanddruids.com)
 
 
 - [Jekyll](https://jekyllrb.com/)


### PR DESCRIPTION
Avoid redirection to https://github.com/DroidsAndDruids/DroidsAndDruids/blob/master/droidsanddruids.com, so I added 'https://' for fix redirection